### PR TITLE
Implement Sorted for Slices on Interfaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/seiflotfy/do
+
+go 1.20

--- a/sorted.go
+++ b/sorted.go
@@ -1,0 +1,37 @@
+package do
+
+import (
+	"errors"
+	"sort"
+)
+
+// Sorted takes an iterable (slice) of elements and returns a new slice containing
+// the elements sorted in ascending order.
+// Example:
+//
+//	sortedInts, err := Sorted([]int{3, 1, 4, 1, 5, 9})
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	// sortedInts will be []int{1, 1, 3, 4, 5, 9}
+func Sorted(iterable interface{}) (interface{}, error) {
+	switch v := iterable.(type) {
+	case []int:
+		sortedSlice := make([]int, len(v))
+		copy(sortedSlice, v)
+		sort.Ints(sortedSlice)
+		return sortedSlice, nil
+	case []float64:
+		sortedSlice := make([]float64, len(v))
+		copy(sortedSlice, v)
+		sort.Float64s(sortedSlice)
+		return sortedSlice, nil
+	case []string:
+		sortedSlice := make([]string, len(v))
+		copy(sortedSlice, v)
+		sort.Strings(sortedSlice)
+		return sortedSlice, nil
+	default:
+		return nil, errors.New("Unsupported type")
+	}
+}

--- a/sorted_test.go
+++ b/sorted_test.go
@@ -1,0 +1,83 @@
+package do
+
+import (
+	"math/rand"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+)
+
+func generateRandomIntSlice(size int) []int {
+	slice := make([]int, size)
+	for i := 0; i < size; i++ {
+		slice[i] = rand.Intn(1000)
+	}
+	return slice
+}
+
+func TestSortedInt(t *testing.T) {
+	iterable := []int{3, 1, 4, 1, 5, 9}
+	expected := []int{1, 1, 3, 4, 5, 9}
+	values, err := Sorted(iterable)
+	if err != nil {
+		t.Error("Error occurred:", err)
+	}
+	if !reflect.DeepEqual(values, expected) {
+		t.Error("Error expected", expected, "got", values)
+	}
+}
+
+func TestSortedFloat64(t *testing.T) {
+	iterable := []float64{3.1, 1.4, 4.1, 5.9}
+	expected := []float64{1.4, 3.1, 4.1, 5.9}
+	values, err := Sorted(iterable)
+	if err != nil {
+		t.Error("Error occurred:", err)
+	}
+	if !reflect.DeepEqual(values, expected) {
+		t.Error("Error expected", expected, "got", values)
+	}
+}
+
+func TestSortedString(t *testing.T) {
+	iterable := []string{"apple", "banana", "cherry"}
+	expected := []string{"apple", "banana", "cherry"}
+	values, err := Sorted(iterable)
+	if err != nil {
+		t.Error("Error occurred:", err)
+	}
+	if !reflect.DeepEqual(values, expected) {
+		t.Error("Error expected", expected, "got", values)
+	}
+}
+
+func TestSortedSpeed(t *testing.T) {
+	// Generate a large random slice of integers
+	iterable := generateRandomIntSlice(10000)
+
+	// Measure the time taken by Sorted function
+	start := time.Now()
+	values1, err := Sorted(iterable)
+	if err != nil {
+		t.Error("Error occurred:", err)
+	}
+	elapsed1 := time.Since(start)
+
+	// For comparison, sort the slice using Go's built-in sort for int slices
+	start = time.Now()
+	values2 := make([]int, len(iterable))
+	copy(values2, iterable)
+	sort.Ints(values2)
+	elapsed2 := time.Since(start)
+
+	// Check if both sorted slices are equal
+	if !reflect.DeepEqual(values1, values2) {
+		t.Error("Error expected", values2, "got", values1)
+	}
+
+	// Check if custom Sorted function is not excessively slower than Go's built-in sort
+	if elapsed1 > 2*elapsed2 {
+		t.Error("Error expected Sorted to be not excessively slower than Go's built-in sort, got", elapsed1, ">", 2*elapsed2)
+	}
+}


### PR DESCRIPTION
## Summary
This PR implements the `Sorted` function in the `do` package to sort slices of
`int`, `float64`, and `string` types. The function returns a new sorted slice
and an error for unsupported types.

## Details
- Added `Sorted` function to sort slices based on their native types.
- Utilized Go's built-in sorting functions for optimal performance.
- Included error handling for unsupported slice types.
- Added tests to verify the functionality of the `Sorted` implementation.
- Included a speed test to ensure the performance is within acceptable limits.

## Future Considerations
If approved, I can enhance this implementation using Go's  generics
feature. This would allow for `Sorted` to be more flexible and
type-safe, capable of sorting slices of any comparable type.

Resolves issue: #10
